### PR TITLE
Exchange img for next/image.

### DIFF
--- a/src/components/InfoElement/InfoElement.jsx
+++ b/src/components/InfoElement/InfoElement.jsx
@@ -22,7 +22,7 @@ export const InfoElement = (props) => {
             <GridContainer justify="center">
                 <GridItem xs={12} sm={12} md={12}>
                     <div className={classes.centered}>
-                        <img className={imageClasses} src={props.image} width={200} height={200}/>
+                        <Image className={imageClasses} src={props.image} width={200} height={200}/>
                     </div>
                     <div>
                         <h3 className={classes.title}>{props.name}</h3>

--- a/src/components/Parallax/Parallax.js
+++ b/src/components/Parallax/Parallax.js
@@ -1,12 +1,9 @@
 import React from 'react'
-// nodejs library that concatenates classes
 import classNames from 'classnames'
-// nodejs library to set properties for components
 import PropTypes from 'prop-types'
-// @material-ui/core components
 import { makeStyles } from '@material-ui/core/styles'
+import Image from 'next/image'
 
-// core components
 import styles from 'src/assets/jss/nextjs-material-kit/components/parallaxStyle.js'
 
 const useStyles = makeStyles(styles)
@@ -42,10 +39,16 @@ export default function Parallax(props) {
       className={parallaxClasses}
       style={{
         ...style,
-        backgroundImage: 'url(' + image + ')',
         transform: transform
       }}
     >
+        <Image
+            src={image}
+            layout="fill"
+            objectFit="cover"
+            priority="true"
+            quality={100}
+        />
       {children}
     </div>
   )


### PR DESCRIPTION
Use next image (since it is finally supported by netlify) to get proper image optimization and therefore much better page loat times.